### PR TITLE
Added support for detecting and specifying ports.

### DIFF
--- a/octoprint_wemoswitch/__init__.py
+++ b/octoprint_wemoswitch/__init__.py
@@ -170,7 +170,7 @@ class wemoswitchPlugin(octoprint.plugin.SettingsPlugin,
 
 		tmp_ret = []
 		for index in range(len(self.discovered_devices)):
-			d = self.get_discovered_device(as_text=as_choice or as_text)
+			d = self.get_discovered_device(index, as_text=as_choice or as_text)
 			if as_choice:
 				tmp_ret.append((index, tmp_ret))
 			else:


### PR DESCRIPTION
Added the ability to support entering an IP address:port number string instead of just a address.  I am using a device (https://dlidirect.com/products/new-pro-switch) that can simulate a wemo plug, however it uses different ports for each of the plugs on the power-strip.  

if no port number is found in the address string, it will simply use your existing code.

I also added a dump into the log in the startup script to detail the information it found in the discover devices (which can help people find their device.)

There is also a method now that will return that device discovery information in a format that should be useful for adding a combo-box/dropdown list to the ui with the found devices (I don't know the OctoPrint UI approach to know how to add it, or I would have added that as well, it should be a combo-box though so people can still add in addresses that were not discovered.)  None of this though should impact anything if you don't want to add this, it's there if desired, but should not impact anything.
