### PR TITLE
0.1.11

### DIFF
--- a/octoprint_wemoswitch/__init__.py
+++ b/octoprint_wemoswitch/__init__.py
@@ -14,6 +14,7 @@ import re
 import threading
 import time
 import pywemo
+from uptime import uptime
 
 try:
 	from octoprint.util import ResettableTimer
@@ -424,6 +425,12 @@ class wemoswitchPlugin(octoprint.plugin.SettingsPlugin,
 			return
 
 		if self._printer.is_printing() or self._printer.is_paused():
+			return
+
+		if (uptime() / 60) <= (self._settings.get_int(["idleTimeout"])):
+			self._wemoswitch_logger.debug("Just booted so wait for time sync.")
+			self._wemoswitch_logger.debug("uptime: {}, comparison: {}".format((uptime() / 60), (self._settings.get_int(["idleTimeout"]))))
+			self._reset_idle_timer()
 			return
 
 		self._wemoswitch_logger.debug("Idle timeout reached after %s minute(s). Waiting for hot end to cool prior to powering off plugs." % self.idleTimeout)

--- a/octoprint_wemoswitch/__init__.py
+++ b/octoprint_wemoswitch/__init__.py
@@ -14,6 +14,7 @@ import re
 import threading
 import time
 import pywemo
+from octoprint.util.version import is_octoprint_compatible
 from uptime import uptime
 
 try:
@@ -227,10 +228,19 @@ class wemoswitchPlugin(octoprint.plugin.SettingsPlugin,
 	##~~ AssetPlugin mixin
 
 	def get_assets(self):
-		return dict(
-			js=["js/jquery-ui.min.js", "js/knockout-sortable.1.2.0.js", "js/fontawesome-iconpicker.js", "js/ko.iconpicker.js", "js/wemoswitch.js"],
-			css=["css/font-awesome.min.css", "css/font-awesome-v4-shims.min.css", "css/fontawesome-iconpicker.css", "css/wemoswitch.css"]
-		)
+		css = ["css/fontawesome-iconpicker.css",
+			   "css/tplinksmartplug.css",
+			   ]
+
+		if not is_octoprint_compatible(">=1.5.0"):
+			css += [
+				"css/font-awesome.min.css",
+				"css/font-awesome-v4-shims.min.css",
+			]
+
+		return {'js': ["js/jquery-ui.min.js", "js/knockout-sortable.1.2.0.js", "js/fontawesome-iconpicker.js",
+					   "js/ko.iconpicker.js", "js/wemoswitch.js"],
+				'css': css}
 
 	##~~ TemplatePlugin mixin
 
@@ -374,7 +384,7 @@ class wemoswitchPlugin(octoprint.plugin.SettingsPlugin,
 			self._timelapse_active = False
 
 		# File Uploaded Event
-		if event == Events.UPLOAD and self._settings.getBoolean(["event_on_upload_monitoring"]):
+		if event == Events.UPLOAD and self._settings.get_boolean(["event_on_upload_monitoring"]):
 			if payload.get("print", False): # implemented in OctoPrint version 1.4.1
 				self._wemoswitch_logger.debug("File uploaded: %s. Turning enabled plugs on." % payload.get("name", ""))
 				self._wemoswitch_logger.debug(payload)

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_wemoswitch"
 plugin_name = "OctoPrint-WemoSwitch"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.10"
+plugin_version = "0.1.11rc1"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/jneilliii/OctoPrint-WemoSwitch"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = ["pywemo"]
+plugin_requires = ["pywemo", "uptime"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_wemoswitch"
 plugin_name = "OctoPrint-WemoSwitch"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.11rc2"
+plugin_version = "0.1.11"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ plugin_package = "octoprint_wemoswitch"
 plugin_name = "OctoPrint-WemoSwitch"
 
 # The plugin's version. Can be overwritten within OctoPrint's internal data via __plugin_version__ in the plugin module
-plugin_version = "0.1.11rc1"
+plugin_version = "0.1.11rc2"
 
 # The plugin's description. Can be overwritten within OctoPrint's internal data via __plugin_description__ in the plugin
 # module


### PR DESCRIPTION
- replace deprecated getBoolen with get_boolean
- remove duplicated bundling of fontawesome 5 if running on OctoPrint 1.5.0+
- add uptime to prevent instant idle timeout with on start option, resolves #54 