### PR TITLE
Update wemoswitch_settings.jinja2 to link back to documentation.

### DIFF
--- a/octoprint_wemoswitch/templates/wemoswitch_settings.jinja2
+++ b/octoprint_wemoswitch/templates/wemoswitch_settings.jinja2
@@ -1,4 +1,5 @@
 <h4>Wemo Switch Settings</h4>
+<p>For details on these settings, see <a href="https://github.com/jneilliii/OctoPrint-WemoSwitch#settings">the source</a>.</p>
 <table class="table table-condensed">
 	<thead>
 		<tr>

--- a/octoprint_wemoswitch/templates/wemoswitch_settings.jinja2
+++ b/octoprint_wemoswitch/templates/wemoswitch_settings.jinja2
@@ -1,5 +1,5 @@
 <h4>Wemo Switch Settings</h4>
-<p>For details on these settings, see <a href="https://github.com/jneilliii/OctoPrint-WemoSwitch#settings">the source</a>.</p>
+<p>For details on these settings, see <a href="https://github.com/jneilliii/OctoPrint-WemoSwitch#settings" target="_blank">the source</a>.</p>
 <table class="table table-condensed">
 	<thead>
 		<tr>


### PR DESCRIPTION
Add a link back to the documentation on the settings.